### PR TITLE
Remove sudo and dist tags from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: java
-sudo: required
 script:
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && bash travis/install.sh || bash travis/install_pr.sh'
 group: stable
-dist: trusty
-sudo: required
 os: linux


### PR DESCRIPTION
Remove 'sudo: required' and 'dist: trusty' from the .travis.yml
file.  Both are depricated.

Fixes #29 